### PR TITLE
Add custom styles and add link information about site, at bottom page

### DIFF
--- a/header.php
+++ b/header.php
@@ -108,6 +108,21 @@
 			 
 			 <div class="credits">
 			 
+			 	<!-- 
+			 	// XTEC ************ AFEGIT - Add link information at bottom "epa" blocs
+			 	// 2016.11.16 @xaviernietosanchez
+			 	-->
+			 	<?php if ( get_option('xtec_blogtype') == 'epa' ){ ?>
+			 	<p>
+			 		<span class="genericon genericon-info"></span> 
+			 		<a href="http://blocs.xtec.cat/blocs_formacio/dossierepa/sobre-aquest-espai">Sobre aquest espai</a>
+			 	</p>
+			 	<br><br>
+			 	<?php } ?>
+			 	<!--
+				// ************ FI
+			 	-->
+
 			 	<p>&copy; <?php echo date("Y") ?> <a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo('name'); ?></a>.</p>
 			 	<p><?php _e('Powered by','fukasawa'); ?> <a href="http://www.wordpress.org">WordPress</a>.</p>
 			 	<p><?php _e('Theme by','fukasawa'); ?> <a href="http://www.andersnoren.se">Anders Nor&eacute;n</a>.</p>

--- a/style.css
+++ b/style.css
@@ -2476,3 +2476,38 @@ img#wpstats { display: none; }
 	color: #666;
 }
 /*//************ FI */
+
+/*//XTEC ************ AFEGIT - Change icon article link
+//2016.11.14  @xaviernietosanchez */
+.main-menu .current-menu-item:before, .main-menu .current_page_item:before {
+  content: '\f501';
+}
+/*//************ FI*/
+
+/*//XTEC ************ AFEGIT - Change color
+//2016.11.14  @xaviernietosanchez */
+.page-title h4 {
+   color: #FFF;
+}
+/*//************ FI*/
+
+/*//XTEC ************ AFEGIT - Hidden containter images (thumbnail, carrousel,...) into principal page
+//2016.11.14  @xaviernietosanchez */
+.single .featured-media {
+    display: none;
+}
+/*//************ FI*/
+
+/*//XTEC ************ AFEGIT - Change color links main-menu
+//2016.11.14  @xaviernietosanchez */
+.main-menu a {
+  color: #494949;
+}
+/*//************ FI*/
+
+/*//XTEC ************ AFEGIT - Hidden posts with caregory "Pendent"
+//2016.11.14  @xaviernietosanchez */
+body.home div.category-pendents{
+	display:none;
+}
+/*//************ FI*/


### PR DESCRIPTION
Modificat el tema per tal d'incloure per defecte els estils i l'enllaç que s'afegien fins ara amb un giny de text:

`<span class="genericon genericon-info"></span> <a href="http://blocs.xtec.cat/blocs_formacio/dossierepa/sobre-aquest-espai">Sobre aquest espai</a>

<style>
.main-menu .current-menu-item:before, .main-menu .current_page_item:before {
  content: '\f501';
}

.page-title h4 {
   color: #FFF;
}

.category, 
.page, 
.single, 
.home {
background-color: #034F84;
background: url(http://blocs.xtec.cat/blocs_formacio/dossierepa/files/2016/02/20150916_101350-1.jpg);
}
.single .featured-media {
    display: none;
}
.main-menu a {
  color: #494949;
}

body.home div.category-pendents{
display:none;
}

</style>`

Per provar-ho:

- Cal tenir en un bloc activat el tema fukasawa.
- Amb la wp_option `xtec_blogtype` amb el valor 'epa' per comprovar l'enllaç.