### PR TITLE
Change to dots '...' instead of category menu 'Pendents'

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -487,4 +487,20 @@ add_action( 'wp_head' , array( 'fukasawa_Customize' , 'fukasawa_header_output' )
 // Enqueue live preview javascript in Theme Customizer admin screen
 add_action( 'customize_preview_init' , array( 'fukasawa_Customize' , 'fukasawa_live_preview' ) );
 
+// XTEC ************ AFEGIT - Change to dots "..." (<span class="genericon genericon-ellipsis"></span>) instead of category menu "pendents"
+// 2016.11.14 @xaviernietosanchez
+function filter_pre_wp_nav_menu( $sorted_menu_items, $args ) {
+	for($i=0;$i <= count($sorted_menu_items);$i++){
+		if( strcasecmp ( $sorted_menu_items[$i]->title , 'pendents' ) == 0 ){
+			$sorted_menu_items[$i]->title = '<span class="genericon genericon-ellipsis"></span>';
+		}
+	}
+    return $sorted_menu_items;
+}
+if ( get_option('xtec_blogtype') == 'epa' ){
+	add_filter( 'wp_nav_menu_objects', 'filter_pre_wp_nav_menu', 10, 2 );
+}
+// ************ FI
+
+
 ?>


### PR DESCRIPTION
Subsituir els menús que es diguin "Pendents" per els punts suspensius `<span class="genericon genericon-ellipsis"></span>` en els blogs EPA i amb el tema fukasawa.

Proves:

- Cal afegir un menú en un blog "epa" i en el títol dir-li "Pendents" o "Pendents".